### PR TITLE
Feat: split records in batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ In addition to the standard [Kafka Connect connector configuration](https://kafk
 | `aws.lambda.invocation.mode` | No | `SYNC` | `SYNC` for a synchronous invocation; otherwise `ASYNC` |
 | `aws.lambda.invocation.failure.mode` | No | `STOP` | Whether to `STOP` processing, or `DROP` and continue after an invocation failure |
 | `aws.lambda.batch.enabled` | No | `true` | `true` to batch messages together before an invocation; otherwise `false` |
+| `aws.lambda.batch.size` | No | 9999999 | Determines max size of array of records, when invoking the Lambda |
+| `aws.lambda.batch.delay.ms` | No | `100` | Time to wait for a lambda invocation before continuing (Period time) |
 | `aws.region` | Yes | | AWS region of the Lambda function |
 | `http.proxy.host` | No | | HTTP proxy host name |
 | `http.proxy.port` | No | | HTTP proxy port number |

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.nordstrom.kafka.connect.lambda</groupId>
     <artifactId>kafka-connect-lambda</artifactId>
-    <version>1.3.0</version>
+    <version>1.5.0</version>
 
     <name>kafka-connect-lambda</name>
     <description>A Kafka Connect Connector for kafka-connect-lambda</description>

--- a/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkConnectorConfig.java
@@ -24,6 +24,14 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
     static final String BATCH_RECORDS_ENABLED_DOC = "Determines whether to send individual records, or an array of records, when invoking the Lambda";
     static final boolean BATCH_RECORDS_ENABLED_DEFAULT = true;
 
+    static final String BATCH_RECORDS_SIZE_KEY = "aws.lambda.batch.size";
+    static final String BATCH_RECORDS_SIZE_DOC = "Determines max size of array of records, when invoking the Lambda";
+    static final int BATCH_RECORDS_SIZE_DEF = 9999999;
+
+    static final String BATCH_RECORDS_DELAY_KEY = "aws.lambda.batch.delay.ms";
+    static final String BATCH_RECORDS_DELAY_DOC = "Determines max delay of invoke between records";
+    static final int BATCH_RECORDS_DELAY_DEF = 100;
+
     static final String RETRIES_MAX_KEY = "retries.max";
     static final String RETRIES_MAX_DOC = "Max number of times to retry the Lambda invocation";
     static final int RETRIES_DEFAULT = 5;
@@ -59,6 +67,14 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
 
     public boolean isBatchingEnabled() {
         return this.getBoolean(BATCH_RECORDS_ENABLED_KEY);
+    }
+
+    public int getBatchSize() {
+        return this.getInt(BATCH_RECORDS_SIZE_KEY);
+    }
+
+    public long getBatchDelay() {
+        return this.getInt(BATCH_RECORDS_DELAY_KEY);
     }
 
     public long getRetryBackoffTimeMillis() {
@@ -111,6 +127,18 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
                 BATCH_RECORDS_ENABLED_DEFAULT,
                 Importance.MEDIUM,
                 BATCH_RECORDS_ENABLED_DOC)
+
+            .define(BATCH_RECORDS_SIZE_KEY,
+                Type.INT,
+                BATCH_RECORDS_SIZE_DEF,
+                Importance.LOW,
+                BATCH_RECORDS_SIZE_DOC)
+
+            .define(BATCH_RECORDS_DELAY_KEY,
+                Type.INT,
+                BATCH_RECORDS_DELAY_DEF,
+                Importance.LOW,
+                BATCH_RECORDS_DELAY_DOC)
 
             .define(RETRIES_MAX_KEY,
                 Type.INT,


### PR DESCRIPTION
Este pr irá permitir que divida o batch recebido em batch's menores, além de espaçar as invocações por um parâmetro de delay.


Atenção: quando a função put() demora muito mais do que o timeout do Poll das mensagens, dá ruim. Dá para expandir isso por um parâmetro de sobrescrita do timeout, mas estou buscando uma solução elegante para isso.